### PR TITLE
Always open text files with utf-8 encoding in Python tools

### DIFF
--- a/tools/build_assets.py
+++ b/tools/build_assets.py
@@ -49,7 +49,7 @@ def build_gametext():
     
     spec_parser = GameTextSpecParser()
     for patch in patches:
-        with open(patch, "r") as spec_file:
+        with open(patch, "r", encoding="utf-8") as spec_file:
             patch_gametext = spec_parser.parse(spec_file)
         gametext.apply_patch(patch_gametext)
 
@@ -97,7 +97,7 @@ def build_warptab():
         warptab = WarpTab.from_binary_file(base_file)
     
     for patch in patches:
-        with open(patch, "r") as yaml_file:
+        with open(patch, "r", encoding="utf-8") as yaml_file:
             patch_warptab = WarpTab.from_yaml_file(yaml_file)
         warptab.apply_patch(patch_warptab)
     

--- a/tools/extract.py
+++ b/tools/extract.py
@@ -27,7 +27,7 @@ def extract_gametext():
          open(bin, "rb") as bin_file:
         gametext = GameTextBinParser().parse(tab_file, bin_file)
     
-    with open(gametext_spec, "w") as gametext_spec_file:
+    with open(gametext_spec, "w", encoding="utf-8") as gametext_spec_file:
         GameTextSpecWriter().write(gametext, gametext_spec_file)
 
 def extract_objects():
@@ -56,7 +56,7 @@ def extract_warp():
     with open(warptab_bin, "rb") as warptab_bin_file:
         warptab = WarpTab.from_binary_file(warptab_bin_file)
     
-    with open(warp_yaml, "w") as warp_yaml_file:
+    with open(warp_yaml, "w", encoding="utf-8") as warp_yaml_file:
         warptab.write_yaml(warp_yaml_file)
 
 def extract_bin(rom: BufferedReader, fs: FSTab):

--- a/tools/gametext.py
+++ b/tools/gametext.py
@@ -613,10 +613,10 @@ def main():
     bin2spec_cmd = subparsers.add_parser("bin2spec", help="Convert GAMETEXT.bin/tab to gametext.spec.")
     bin2spec_cmd.add_argument("--tab", type=argparse.FileType("rb"), help="The GAMETEXT.tab file to read.", required=True)
     bin2spec_cmd.add_argument("--bin", type=argparse.FileType("rb"), help="The GAMETEXT.bin file to read.", required=True)
-    bin2spec_cmd.add_argument("-o", "--output", type=argparse.FileType("w"), help="The spec file to write.", required=True)
+    bin2spec_cmd.add_argument("-o", "--output", type=argparse.FileType("w", encoding="utf-8"), help="The spec file to write.", required=True)
 
     spec2bin_cmd = subparsers.add_parser("spec2bin", help="Convert gametext.spec files to GAMETEXT.bin/tab.")
-    spec2bin_cmd.add_argument("spec", nargs="+", action="extend", type=argparse.FileType("r"), 
+    spec2bin_cmd.add_argument("spec", nargs="+", action="extend", type=argparse.FileType("r", encoding="utf-8"), 
                               help="The spec files to read. Later files will be merged onto earlier files.")
     spec2bin_cmd.add_argument("--tab", type=argparse.FileType("wb"), help="The GAMETEXT.tab file to write.", required=True)
     spec2bin_cmd.add_argument("--bin", type=argparse.FileType("wb"), help="The GAMETEXT.bin file to write.", required=True)
@@ -626,7 +626,7 @@ def main():
     mkpatch_cmd.add_argument("--bin1", type=argparse.FileType("rb"), help="The base GAMETEXT.bin file.", required=True)
     mkpatch_cmd.add_argument("--tab2", type=argparse.FileType("rb"), help="The target GAMETEXT.tab file.", required=True)
     mkpatch_cmd.add_argument("--bin2", type=argparse.FileType("rb"), help="The target GAMETEXT.bin file.", required=True)
-    mkpatch_cmd.add_argument("-o", "--output", type=argparse.FileType("w"), help="The patch spec file to write.", required=True)
+    mkpatch_cmd.add_argument("-o", "--output", type=argparse.FileType("w", encoding="utf-8"), help="The patch spec file to write.", required=True)
 
     args, _ = parser.parse_known_args()
     cmd = args.command


### PR DESCRIPTION
Ensures that text IO works on all systems. :slightly_smiling_face: 